### PR TITLE
Move formula to 'base' environment

### DIFF
--- a/FORMULA.dom0
+++ b/FORMULA.dom0
@@ -1,7 +1,7 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 package-name:       qubes-mgmt-salt-dom0-virtual-machines
-saltenv:            dom0
+saltenv:            base
 version:            3.1.1
 release:            1
 name:               virtual-machines-formula

--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ configuring virtual-machine AppVM's.
 
 Uses pillar data to define default VM names and configuration details.  Default
 settings can be overridden in pillar data located at:
-    ``/srv/pillar/dom0/qvm/init.sls``
+    ``/srv/pillar/base/qvm/init.sls``
 
 Available states
 ================

--- a/pillar/qvm/init.top
+++ b/pillar/qvm/init.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm

--- a/qvm/anon-whonix.top
+++ b/qvm/anon-whonix.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.anon-whonix

--- a/qvm/personal.top
+++ b/qvm/personal.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.personal

--- a/qvm/sys-firewall.top
+++ b/qvm/sys-firewall.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.sys-firewall

--- a/qvm/sys-net-with-usb.top
+++ b/qvm/sys-net-with-usb.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.sys-net-with-usb

--- a/qvm/sys-net.top
+++ b/qvm/sys-net.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.sys-net

--- a/qvm/sys-usb.top
+++ b/qvm/sys-usb.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.sys-usb

--- a/qvm/sys-whonix.top
+++ b/qvm/sys-whonix.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.sys-whonix

--- a/qvm/untrusted.top
+++ b/qvm/untrusted.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.untrusted

--- a/qvm/vault.top
+++ b/qvm/vault.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.vault

--- a/qvm/work.top
+++ b/qvm/work.top
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
-dom0:
+base:
   dom0:
     - match: nodegroup
     - qvm.work

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec
@@ -37,54 +37,66 @@ qubesctl saltutil.clear_cache -l quiet --out quiet > /dev/null || true
 qubesctl saltutil.sync_all refresh=true -l quiet --out quiet > /dev/null || true
 
 # Enable States
-#qubesctl top.enable qvm.sys-net saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.sys-firewall saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.sys-whonix saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.anon-whonix saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.personal saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.work saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.untrusted saltenv=dom0 -l quiet --out quiet > /dev/null || true
-#qubesctl top.enable qvm.vault saltenv=dom0 -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.sys-net -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.sys-firewall -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.sys-whonix -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.anon-whonix -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.personal -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.work -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.untrusted -l quiet --out quiet > /dev/null || true
+#qubesctl top.enable qvm.vault -l quiet --out quiet > /dev/null || true
 
 # Enable Pillar States
-qubesctl top.enable qvm saltenv=dom0 pillar=true -l quiet --out quiet > /dev/null || true
+qubesctl top.enable qvm pillar=true -l quiet --out quiet > /dev/null || true
+
+# Migrate enabled tops from dom0 to base environment
+for top in sys-net sys-firewall sys-whonix anon-whonix personal work untrusted vault sys-net-with-usb; do
+    if [ -r /srv/salt/_tops/dom0/qvm.$top.top ]; then
+        rm -f /srv/salt/_tops/dom0/qvm.$top.top
+        qubesctl top.enable qvm.$top -l quiet --out quiet > /dev/null || true
+    fi
+done
+
+if [ -r /srv/pillar/_tops/dom0/qvm.top ]; then
+    rm -f /srv/pillar/_tops/dom0/qvm.top
+fi
 
 %files
 %defattr(-,root,root)
 %doc LICENSE README.rst
-%attr(750, root, root) %dir /srv/formulas/dom0/virtual-machines-formula
-/srv/formulas/dom0/virtual-machines-formula/README.rst
-/srv/formulas/dom0/virtual-machines-formula/LICENSE
-/srv/formulas/dom0/virtual-machines-formula/qvm/anon-whonix.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/anon-whonix.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/personal.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/personal.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-firewall.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-firewall.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-net.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-net.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-net-with-usb.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-net-with-usb.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-usb.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-usb.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-whonix.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/sys-whonix.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-debian-7.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-debian-8.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-fedora-21-minimal.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-fedora-21.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/template.jinja
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-whonix-gw.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/template-whonix-ws.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/untrusted.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/untrusted.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/vault.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/vault.top
-/srv/formulas/dom0/virtual-machines-formula/qvm/work.sls
-/srv/formulas/dom0/virtual-machines-formula/qvm/work.top
+%attr(750, root, root) %dir /srv/formulas/base/virtual-machines-formula
+/srv/formulas/base/virtual-machines-formula/README.rst
+/srv/formulas/base/virtual-machines-formula/LICENSE
+/srv/formulas/base/virtual-machines-formula/qvm/anon-whonix.sls
+/srv/formulas/base/virtual-machines-formula/qvm/anon-whonix.top
+/srv/formulas/base/virtual-machines-formula/qvm/personal.sls
+/srv/formulas/base/virtual-machines-formula/qvm/personal.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-firewall.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-firewall.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-net.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-net.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-net-with-usb.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-net-with-usb.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-usb.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-usb.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-whonix.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-whonix.top
+/srv/formulas/base/virtual-machines-formula/qvm/template-debian-7.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-debian-8.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-fedora-21-minimal.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-fedora-21.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template.jinja
+/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-gw.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-ws.sls
+/srv/formulas/base/virtual-machines-formula/qvm/untrusted.sls
+/srv/formulas/base/virtual-machines-formula/qvm/untrusted.top
+/srv/formulas/base/virtual-machines-formula/qvm/vault.sls
+/srv/formulas/base/virtual-machines-formula/qvm/vault.top
+/srv/formulas/base/virtual-machines-formula/qvm/work.sls
+/srv/formulas/base/virtual-machines-formula/qvm/work.top
 
-%attr(750, root, root) %dir /srv/pillar/dom0/qvm
-%config(noreplace) /srv/pillar/dom0/qvm/init.sls
-/srv/pillar/dom0/qvm/init.top
+%attr(750, root, root) %dir /srv/pillar/base/qvm
+%config(noreplace) /srv/pillar/base/qvm/init.sls
+/srv/pillar/base/qvm/init.top
 
 %changelog


### PR DESCRIPTION
This should make it easier to reuse states where both dom0 and VMs are configured from the same formula.

@woju what do you think about this? Is it good idea? This would mean in practice abandoning `dom0` salt environment.