### PR TITLE
Updated formulas for Whonix VMs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,10 @@ Default Disposable VM template - fedora-25-dvm AppVM
 -------------------
 Whonix workstation AppVM.
 
+``qvm.whonix-ws-dvm``
+-------------------
+Whonix workstation AppVM for Whonix Disposable VMs.
+
 ``qvm.template-fedora-21``
 --------------------------
 Fedora-21 TemplateVM

--- a/qvm/anon-whonix.sls
+++ b/qvm/anon-whonix.sls
@@ -29,21 +29,12 @@ present:
   - label:     red
 prefs:
   - netvm:     sys-whonix
+tags:
+  - add:
+    - anon-vm
 require:
   - pkg:       template-whonix-ws
   - qvm:       sys-whonix
 {%- endload %}
 
 {{ load(defaults) }}
-
-{% load_yaml as template -%}
-name:          whonix-ws
-force:         true
-prefs:
-  - netvm:     sys-whonix
-require:
-  - pkg:       template-whonix-ws
-  - qvm:       sys-whonix
-{%- endload %}
-
-{{ load(template) }}

--- a/qvm/sys-whonix.sls
+++ b/qvm/sys-whonix.sls
@@ -39,14 +39,3 @@ require:
 
 {{ load(defaults) }}
 
-{% load_yaml as template -%}
-name:          whonix-gw
-force:         true
-prefs:
-  - netvm:     sys-whonix
-require:
-  - pkg:       template-whonix-gw
-  - qvm:       sys-whonix
-{%- endload %}
-
-{{ load(template) }}

--- a/qvm/template-whonix-gw.sls
+++ b/qvm/template-whonix-gw.sls
@@ -15,3 +15,10 @@ template-whonix-gw:
   pkg.installed:
     - name:     qubes-template-whonix-gw
     - fromrepo: qubes-templates-community
+
+whonix-gw-update-policy:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.UpdatesProxy
+    - text:
+      - whonix-gw $default allow,target=sys-whonix
+      - whonix-gw $anyvm deny

--- a/qvm/template-whonix-ws.sls
+++ b/qvm/template-whonix-ws.sls
@@ -15,3 +15,17 @@ template-whonix-ws:
   pkg.installed:
     - name:     qubes-template-whonix-ws
     - fromrepo: qubes-templates-community
+
+whonix-ws-update-policy:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.UpdatesProxy
+    - text:
+      - whonix-ws $default allow,target=sys-whonix
+      - whonix-ws $anyvm deny
+
+# this is for whonix-ws based VMs
+whonix-get-date-policy:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.GetDate
+    - text:
+      - $tag:anon-vm $anyvm deny

--- a/qvm/template.jinja
+++ b/qvm/template.jinja
@@ -21,6 +21,8 @@
     'exists',
     'prefs',
     'service',
+    'features',
+    'tags',
     'start',
     'running',
     'pause',

--- a/qvm/whonix-ws-dvm.sls
+++ b/qvm/whonix-ws-dvm.sls
@@ -2,34 +2,34 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 ##
-# qvm.anon-whonix
+# qvm.whonix-ws-dvm
 # ===============
 #
-# Installs 'anon-whonix' AppVM.
+# Installs 'whonix-ws-dvm' AppVM as a base for Disposable VMs.
 #
 # Pillar data will also be merged if available within the ``qvm`` pillar key:
-#   ``qvm:anon-whonix``
+#   ``qvm:whonix-ws-dvm``
 #
 # located in ``/srv/pillar/dom0/qvm/init.sls``
 #
 # Execute:
-#   qubesctl state.sls qvm.anon-whonix dom0
+#   qubesctl state.sls qvm.whonix-ws-dvm dom0
 ##
 
 include:
   - qvm.template-whonix-ws
   - qvm.sys-whonix
-  - qvm.whonix-ws-dvm
 
 {%- from "qvm/template.jinja" import load -%}
 
 {% load_yaml as defaults -%}
-name:          anon-whonix
+name:          whonix-ws-dvm
 present:
   - template:  whonix-ws
   - label:     red
 prefs:
   - netvm:     sys-whonix
+  - template-for-dispvms: true
   - default-dispvm: whonix-ws-dvm
 tags:
   - add:
@@ -37,7 +37,6 @@ tags:
 require:
   - pkg:       template-whonix-ws
   - qvm:       sys-whonix
-  - qvm:       whonix-ws-dvm
 {%- endload %}
 
 {{ load(defaults) }}

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec
@@ -80,6 +80,7 @@ fi
 /srv/formulas/base/virtual-machines-formula/qvm/untrusted.top
 /srv/formulas/base/virtual-machines-formula/qvm/vault.sls
 /srv/formulas/base/virtual-machines-formula/qvm/vault.top
+/srv/formulas/base/virtual-machines-formula/qvm/whonix-ws-dvm.sls
 /srv/formulas/base/virtual-machines-formula/qvm/work.sls
 /srv/formulas/base/virtual-machines-formula/qvm/work.top
 


### PR DESCRIPTION
Main chainges:
 - direct qubes.UpdatesProxy to sys-whonix
 - cut VMs from qubes.GetDate service
 - create whonix-ws-dvm and use as a base for DispVMs started by anon-whonix
   (and others tagged with `anon-vm`)

There are probably many possible improvements, but this is minimal set to have Whonix AppVMs and DispVMs running on Qubes OS 4.0

Cc: @adrelanos

https://phabricator.whonix.org/T463
QubesOS/qubes-issues#1954