### PR TITLE
  - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm

### DIFF
--- a/qvm/sys-whonix.sls
+++ b/qvm/sys-whonix.sls
@@ -33,6 +33,7 @@ prefs:
   - netvm:     sys-firewall
   - provides-network: true
   - autostart: true
+  - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm
 require:
   - pkg:       template-whonix-gw-{{ whonix.whonix_version }}
   - qvm:       sys-firewall


### PR DESCRIPTION
Please very carefully review.
Untested.

` - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm` similar to https://github.com/QubesOS/qubes-mgmt-salt-dom0-virtual-machines/blob/master/qvm/anon-whonix.sls#L34

Would that work?

Would this fail if whonix-ws-14-dvm does not (yet) exist?

Reason: was somehow still set to whonix-ws-dvm on my system which leads to confusion.
Use case: opening links from Whonix-Gateway such as when seeing some link in konsole or whonixcheck, it could be opened safely in a DispVM based on whonix-ws-14-dvm.

What this is NOT: disposable sys-whonix

//@viq
