### PR TITLE
whonix: Add pillar file for easily enabling templates testing repository

### DIFF
--- a/pillar/qvm/whonix-testing.sls
+++ b/pillar/qvm/whonix-testing.sls
@@ -1,0 +1,4 @@
+qvm:
+    whonix:
+        repo: qubes-templates-community-testing
+

--- a/pillar/qvm/whonix-testing.top
+++ b/pillar/qvm/whonix-testing.top
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  dom0:
+    - match: nodegroup
+    - qvm.whonix-testing

--- a/qvm/template-whonix-gw.sls
+++ b/qvm/template-whonix-gw.sls
@@ -16,7 +16,7 @@
 template-whonix-gw-{{ whonix.whonix_version }}:
   pkg.installed:
     - name:     qubes-template-whonix-gw-{{ whonix.whonix_version }}
-    - fromrepo: qubes-templates-community
+    - fromrepo: {{ whonix.whonix_repo }}
 
 whonix-gw-tag:
   qvm.vm:

--- a/qvm/template-whonix-ws.sls
+++ b/qvm/template-whonix-ws.sls
@@ -16,7 +16,7 @@
 template-whonix-ws-{{ whonix.whonix_version }}:
   pkg.installed:
     - name:     qubes-template-whonix-ws-{{ whonix.whonix_version }}
-    - fromrepo: qubes-templates-community
+    - fromrepo: {{ whonix.whonix_repo }}
 
 whonix-ws-tag:
   qvm.vm:

--- a/qvm/whonix-ws-dvm.sls
+++ b/qvm/whonix-ws-dvm.sls
@@ -45,7 +45,7 @@ require:
   - qvm:       sys-whonix
 {%- endload %}
 
-qvm-appmenus --update whonix-ws-dvm:
+qvm-appmenus --update whonix-ws-{{ whonix.whonix_version }}-dvm:
   cmd.run:
     - runas: {{ gui_user }}
     - onchanges:

--- a/qvm/whonix.jinja
+++ b/qvm/whonix.jinja
@@ -1,1 +1,2 @@
 {% set whonix_version = salt['pillar.get']('qvm:whonix:version', '14') %}
+{% set whonix_repo = salt['pillar.get']('qvm:whonix:repo', 'qubes-templates-community') %}

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
@@ -90,6 +90,8 @@ fi
 %config(noreplace) /srv/pillar/base/qvm/init.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-net-as-usbvm.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-net-as-usbvm.top
+%config(noreplace) /srv/pillar/base/qvm/whonix-testing.sls
+%config(noreplace) /srv/pillar/base/qvm/whonix-testing.top
 /srv/pillar/base/qvm/init.top
 
 %config(noreplace) /etc/salt/minion.d/formula-virtual-machines.conf


### PR DESCRIPTION
Usage:

    qubesctl top.enable qvm.whonix-testing pillar=true

then proceed with:

    qubectl state.sls qvm.anon-whonix

Fixes QubesOS/qubes-issues#4087

Also, fix one missing part for versioned templates