### PR TITLE
Allow sys-gui to manage itself

### DIFF
--- a/qvm/sys-gui.sls
+++ b/qvm/sys-gui.sls
@@ -60,6 +60,7 @@ sys-gui-rpc:
   file.append:
     - text: |
         sys-gui @tag:guivm-sys-gui allow,target=dom0
+        sys-gui sys-gui allow,target=dom0
 
 # GuiVM (AdminVM) with global 'ro' permissions
 {% if salt['pillar.get']('qvm:sys-gui:admin-global-permissions') == 'ro' %}
@@ -68,6 +69,7 @@ sys-gui-rpc:
     - text: |
         sys-gui @adminvm allow,target=dom0
         sys-gui @tag:guivm-sys-gui allow,target=dom0
+        sys-gui sys-gui allow,target=dom0
 {% endif %}
 
 {% if salt['pillar.get']('qvm:sys-gui:admin-global-permissions') == 'rwx' %}
@@ -77,4 +79,5 @@ sys-gui-rpc:
     - text: |
         sys-gui @adminvm allow,target=dom0
         sys-gui @tag:guivm-sys-gui allow,target=dom0
+        sys-gui sys-gui allow,target=dom0
 {% endif %}


### PR DESCRIPTION
With QubesOS/qubes-core-admin#326, the admin.vm.List endpoint only
lists the VMs allowed by policy. This confuses qvm-start-gui, because
it sees sys-gui listed as a guivm for other machines, but doesn't see
it in the output of admin.vm.List.