### PR TITLE
sys-gui-gpu

### DIFF
--- a/pillar/qvm/sys-gui-gpu.sls
+++ b/pillar/qvm/sys-gui-gpu.sls
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+qvm:
+    sys-gui-gpu:
+        admin-global-permissions: 'rwx'
+    sys-gui-gpu-vm:
+        password-hash: '$1$eByLDWM4$RgCTKI9aKAsNSbKopFSZ11'
+        # TODO proper password setting
+        # Password = 123456

--- a/pillar/qvm/sys-gui-gpu.top
+++ b/pillar/qvm/sys-gui-gpu.top
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+base:
+  dom0:
+    - match: nodegroup
+    - qvm.sys-gui-gpu
+  sys-gui-gpu:
+    - qvm.sys-gui-gpu

--- a/qvm/sys-gui-gpu-attach-gpu.sls
+++ b/qvm/sys-gui-gpu-attach-gpu.sls
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# qvm.sys-gui-gpu-vm-attach-gpu
+# ===========
+##
+
+sys-gui-gpu-attach-gpu:
+  qvm.devices:
+    - name: sys-gui-gpu
+    - attach:
+      - pci:dom0:00_02.0:
+        - permissive: true

--- a/qvm/sys-gui-gpu-detach-gpu.sls
+++ b/qvm/sys-gui-gpu-detach-gpu.sls
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# qvm.sys-gui-gpu-vm-detach-gpu
+# ===========
+##
+
+sys-gui-gpu-attach-gpu:
+  qvm.devices:
+    - name: sys-gui-gpu
+    - detach:
+      - pci:dom0:00_02.0: []

--- a/qvm/sys-gui-gpu-vm.sls
+++ b/qvm/sys-gui-gpu-vm.sls
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# qvm.sys-gui-gpu-vm
+# ===========
+##
+
+/home/user/.config/autostart/qvm-start-daemon.desktop:
+  file.managed:
+    - user: user
+    - mode: 640
+    - makedirs: True
+    - contents: |
+        [Desktop Entry]
+        Name=Qubes Guid/Pacat
+        Comment=Starts GUI/AUDIO daemon for Qubes VMs
+        Icon=qubes
+        Exec=qvm-start-daemon --all --watch
+        Terminal=false
+        Type=Application
+
+/rw/config/rc.local:
+  file.append:
+    - text: |
+        sudo usermod -p '{{ salt['pillar.get']('qvm:sys-gui-gpu-vm:password-hash', '!') }}' user

--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+##
+# qvm.sys-gui-gpu
+# ===========
+##
+
+sys-gui-gpu-template:
+  pkg.installed:
+    - name: qubes-template-{{ salt['pillar.get']('qvm:sys-gui-gpu:template', 'fedora-30-xfce') }}
+
+{% from "qvm/template.jinja" import load -%}
+{% from "qvm/template-gui.jinja" import gui_common -%}
+
+{% load_yaml as defaults -%}
+name:          sys-gui-gpu
+present:
+  - label:     black
+  - maxmem:    4000
+  - template:  {{ salt['pillar.get']('qvm:sys-gui-gpu:template', 'fedora-30-xfce') }}
+prefs:
+  - virt_mode: hvm
+  - netvm:     ""
+  - guivm:     ""
+  - audiovm:   ""
+  - memory:    1000
+  - autostart: false #TODO true
+  - kernelopts: "nopat iommu=soft swiotlb=8192 root=/dev/mapper/dmroot ro console=hvc0 xen_scrub_pages=0"
+features:
+  - enable:
+    - no-default-kernelopts
+  - set:
+    - video-model: none
+service:
+  - enable:
+    - lightdm
+    - guivm-gui-agent
+{%- endload %}
+
+{{ load(defaults) }}
+{{ gui_common(defaults.name) }}
+

--- a/qvm/sys-gui-gpu.top
+++ b/qvm/sys-gui-gpu.top
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# vim: set syntax=yaml ts=2 sw=2 sts=2 et :
+
+# Installs 'sys-gui' GuiVM.
+#
+# Pillar data will also be merged if available within the ``qvm`` pillar key:
+#   ``qvm:sys-gui``
+#
+# located in ``/srv/pillar/dom0/qvm/init.sls``
+#
+# Execute:
+#   qubesctl top.enable qvm.sys-gui
+#   qubesctl --all state.highstate
+
+base:
+  dom0:
+    - match: nodegroup
+    - qvm.sys-gui-gpu
+  {{ salt['pillar.get']('qvm:sys-gui:template', 'fedora-30-xfce') }}:
+    - qvm.sys-gui-template
+  sys-gui-gpu:
+    - qvm.sys-gui-vm
+    - qvm.sys-gui-gpu-vm

--- a/qvm/sys-gui-template.sls
+++ b/qvm/sys-gui-template.sls
@@ -55,3 +55,21 @@ sys-gui-xfce:
       - xfconf
       - xfdesktop
       - xfwm4
+
+/etc/systemd/system/lightdm.service.d/qubes.conf:
+  file.managed:
+    - makedirs: True
+    - contents: |
+        [Unit]
+        ConditionPathExists=/var/run/qubes-service/lightdm
+        [Install]
+        WantedBy=multi-user.target
+
+sys-gui-template-lightdm:
+  cmd.run:
+    - name: systemctl enable lightdm
+
+sys-gui-template-lock-root:
+  user.present:
+    - name: root
+    - password: '!!'

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
@@ -81,6 +81,12 @@ fi
 /srv/formulas/base/virtual-machines-formula/qvm/sys-gui-template.sls
 /srv/formulas/base/virtual-machines-formula/qvm/sys-gui-vm.sls
 /srv/formulas/base/virtual-machines-formula/qvm/sys-gui.top
+/srv/formulas/base/virtual-machines-formula/qvm/sys-gui-gpu.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-gui-gpu-vm.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-gui-gpu-attach-gpu.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-gui-gpu-detach-gpu.sls
+/srv/formulas/base/virtual-machines-formula/qvm/sys-gui-gpu.top
+/srv/formulas/base/virtual-machines-formula/qvm/template-gui.jinja
 /srv/formulas/base/virtual-machines-formula/qvm/sys-audio.sls
 /srv/formulas/base/virtual-machines-formula/qvm/sys-audio-template.sls
 /srv/formulas/base/virtual-machines-formula/qvm/sys-audio-vm.sls
@@ -120,6 +126,8 @@ fi
 %config(noreplace) /srv/pillar/base/qvm/sys-gui.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-as-audiovm.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-as-audiovm.top
+%config(noreplace) /srv/pillar/base/qvm/sys-gui-gpu.top
+%config(noreplace) /srv/pillar/base/qvm/sys-gui-gpu.sls
 /srv/pillar/base/qvm/init.top
 
 %config(noreplace) /etc/salt/minion.d/formula-virtual-machines.conf


### PR DESCRIPTION
Draft of sys-gui-gpu salt config

TODO:
- [x] make sure sys-gui-gpu is not running when GPU is attached
- [x] user password ~from dom0 (only in sys-gui-gpu, not in template)~ configurable with pillar
- [x] fix features setting
- [x] fix keyboard layout setting
- [x] add pillar
- [x] squash commits
- [x] disable root account in sys-gui-gpu
- [x] debug lightdm service enable
- [x] debug password setting

Depends on: QubesOS/qubes-core-admin#341, QubesOS/qubes-gui-agent-linux#97, libvirt&xen&qemu IGD passthrough patches

Part of: QubesOS/qubes-issues#2618