### PR TITLE
Adjust for dummy-psu packages name change

### DIFF
--- a/qvm/sys-gui-template.sls
+++ b/qvm/sys-gui-template.sls
@@ -32,7 +32,8 @@ sys-gui-xfce:
       - xfconf
       - xfwm4
 {% if grains['os'] == 'Fedora' %}
-      - dummy-psu-vm
+      - dummy-psu-receiver
+      - dummy-psu-module
       - dummy-backlight-vm
       - adwaita-gtk2-theme
       - adwaita-icon-theme

--- a/qvm/sys-gui.sls
+++ b/qvm/sys-gui.sls
@@ -10,7 +10,7 @@ qubes-template-{{ salt['pillar.get']('qvm:sys-gui:template', 'fedora-32-xfce') }
   pkg.installed: []
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
-dummy-psu-dom0:
+dummy-psu-sender:
   pkg.installed: []
 {% endif %}
 {% if 'backlight' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}


### PR DESCRIPTION
It's now dummy-psu-sender/dummy-psu-receiver.

QubesOS/qubes-issues#4186