### PR TITLE
Do not disable xscreensaver in sys-gui

### DIFF
--- a/qvm/sys-gui-vm.sls
+++ b/qvm/sys-gui-vm.sls
@@ -7,7 +7,7 @@
 ##
 
 # WIP: currently use default user 'user'
-{% for autostart in ['xscreensaver', 'xscreensaver-autostart', 'nm-applet'] %}
+{% for autostart in ['nm-applet'] %}
 /home/user/.config/autostart/{{autostart}}.desktop:
   file.managed:
     - user: user


### PR DESCRIPTION
Something needs to lock the screen. Lets do it from inside sys-gui (also
the hybrid one), for consistency. This way it will be also easier to
manage.

QubesOS/qubes-issues#4186