### PR TITLE
Use new qvm.template_installed state

### DIFF
--- a/pillar/qvm/init.sls
+++ b/pillar/qvm/init.sls
@@ -19,14 +19,14 @@ qvm-disabled:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - pkg:       template-whonix-gw
+      - qvm:       template-whonix-gw
       - qvm:       test-sys-whonix
 
   whonix-ws:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - pkg:       template-whonix-ws
+      - qvm:       template-whonix-ws
       - qvm:       test-sys-whonix
 
   sys-whonix:
@@ -38,7 +38,7 @@ qvm-disabled:
     #  - flags:
     #    - proxy
     require:
-      - pkg:       template-whonix-gw
+      - qvm:       template-whonix-gw
       - qvm:       test-sys-firewall
 
   anon-whonix:
@@ -46,39 +46,39 @@ qvm-disabled:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - pkg:       template-whonix-ws
+      - qvm:       template-whonix-ws
       - qvm:       test-sys-whonix
 
   work:
     name:          test-work
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
       - qvm:       test-sys-firewall
 
   personal:
     name:          test-personal
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
       - qvm:       test-sys-firewall
 
   untrusted:
     name:          test-untrusted
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
       - qvm:       test-sys-firewall
 
   vault:
     name:          test-vault
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
 
   sys-net:
     name:          test-sys-net
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
 
   sys-firewall:
     name:          test-sys-firewall
     require:
-      - pkg:       template-fedora-34
+      - qvm:       template-fedora-34
       - qvm:       test-sys-net

--- a/qvm/anon-whonix.sls
+++ b/qvm/anon-whonix.sls
@@ -36,7 +36,7 @@ tags:
   - add:
     - anon-vm
 require:
-  - pkg:       template-whonix-ws-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-ws-{{ whonix.whonix_version }}
   - qvm:       sys-whonix
   - qvm:       whonix-ws-{{ whonix.whonix_version }}-dvm
 {%- endload %}

--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -7,8 +7,8 @@
 ##
 
 sys-gui-gpu-template:
-  pkg.installed:
-    - name: qubes-template-{{ salt['pillar.get']('qvm:sys-gui-gpu:template', 'fedora-34-xfce') }}
+  qvm.template_installed:
+    - name: {{ salt['pillar.get']('qvm:sys-gui-gpu:template', 'fedora-34-xfce') }}
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui-gpu:dummy-modules', []) %}
 dummy-psu-dom0:

--- a/qvm/sys-whonix.sls
+++ b/qvm/sys-whonix.sls
@@ -34,7 +34,7 @@ prefs:
   - provides-network: true
   - autostart: true
 require:
-  - pkg:       template-whonix-gw-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-gw-{{ whonix.whonix_version }}
   - qvm:       sys-firewall
 {%- endload %}
 

--- a/qvm/template-whonix-gw.sls
+++ b/qvm/template-whonix-gw.sls
@@ -14,8 +14,8 @@
 {% import "qvm/whonix.jinja" as whonix -%}
 
 template-whonix-gw-{{ whonix.whonix_version }}:
-  pkg.installed:
-    - name:     qubes-template-whonix-gw-{{ whonix.whonix_version }}
+  qvm.template_installed:
+    - name:     whonix-gw-{{ whonix.whonix_version }}
     - fromrepo: {{ whonix.whonix_repo }}
 
 whonix-gw-tag:

--- a/qvm/template-whonix-ws.sls
+++ b/qvm/template-whonix-ws.sls
@@ -14,8 +14,8 @@
 {% import "qvm/whonix.jinja" as whonix -%}
 
 template-whonix-ws-{{ whonix.whonix_version }}:
-  pkg.installed:
-    - name:     qubes-template-whonix-ws-{{ whonix.whonix_version }}
+  qvm.template_installed:
+    - name:     whonix-ws-{{ whonix.whonix_version }}
     - fromrepo: {{ whonix.whonix_repo }}
 
 whonix-ws-tag:

--- a/qvm/whonix-ws-dvm.sls
+++ b/qvm/whonix-ws-dvm.sls
@@ -41,7 +41,7 @@ features:
   - enable:
     - appmenus-dispvm
 require:
-  - pkg:       template-whonix-ws-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-ws-{{ whonix.whonix_version }}
   - qvm:       sys-whonix
 {%- endload %}
 


### PR DESCRIPTION
Templates are no longer recorded in rpmdb, so pkg.installed doesn't work
anymore

QubesOS/qubes-issues#2534