### PR TITLE
Use qvm.template_installed for installing template for sys-gui too

### DIFF
--- a/qvm/sys-gui-vnc.sls
+++ b/qvm/sys-gui-vnc.sls
@@ -6,8 +6,8 @@
 # ===============
 ##
 
-qubes-template-{{ salt['pillar.get']('qvm:sys-gui-vnc:template', 'fedora-34-xfce') }}:
-  pkg.installed: []
+{{ salt['pillar.get']('qvm:sys-gui-vnc:template', 'fedora-34-xfce') }}:
+  qvm.template_installed: []
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) %}
 dummy-psu-sender:

--- a/qvm/sys-gui.sls
+++ b/qvm/sys-gui.sls
@@ -6,8 +6,8 @@
 # ===========
 ##
 
-qubes-template-{{ salt['pillar.get']('qvm:sys-gui:template', 'fedora-34-xfce') }}:
-  pkg.installed: []
+{{ salt['pillar.get']('qvm:sys-gui:template', 'fedora-34-xfce') }}:
+  qvm.template_installed: []
 
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
 dummy-psu-sender:


### PR DESCRIPTION
5ed1278 "Use new qvm.template_installed state" missed two cases.