### PR TITLE
Improve handling USB controllers and HID

### DIFF
--- a/pillar/qvm/sys-usb-allow-mouse.sls
+++ b/pillar/qvm/sys-usb-allow-mouse.sls
@@ -1,0 +1,3 @@
+qvm:
+  sys-usb:
+    mouse-action: allow

--- a/pillar/qvm/sys-usb-allow-mouse.top
+++ b/pillar/qvm/sys-usb-allow-mouse.top
@@ -1,0 +1,4 @@
+base:
+  dom0:
+    - match: nodegroup
+    - qvm.sys-usb-allow-mouse

--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -59,14 +59,18 @@ service:
 sys-usb-input-proxy:
   file.prepend:
     - name: /etc/qubes-rpc/policy/qubes.InputMouse
+{% if salt['pillar.get']('qvm:sys-usb:mouse-action', 'ask') == 'ask' %}
+    - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 ask,user=root,default_target=sys-gui-gpu
+{% elif salt['pillar.get']('qvm:sys-usb:mouse-action', 'ask') == 'allow' %}
     - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 allow,user=root,target=sys-gui-gpu
+{% endif %}
     - require:
       - file: sys-usb-previous-rpc
 
 sys-usb-previous-rpc:
   file.line:
     - name: /etc/qubes-rpc/policy/qubes.InputMouse
-    - match: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 allow,user=root
+    - match: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0
     - mode: delete
 
 {{ load(defaults) }}

--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -79,7 +79,11 @@ qubes-input-proxy:
 sys-usb-input-proxy:
   file.prepend:
     - name: /etc/qubes-rpc/policy/qubes.InputMouse
+{% if salt['pillar.get']('qvm:sys-usb:mouse-action', 'ask') == 'ask' %}
+    - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 ask,user=root,default_target=dom0
+{% elif salt['pillar.get']('qvm:sys-usb:mouse-action', 'ask') == 'allow' %}
     - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 allow,user=root
+{% endif %}
     - require:
       - pkg:       qubes-input-proxy
 

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
@@ -133,6 +133,8 @@ fi
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-gpu.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-vnc.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-vnc.top
+%config(noreplace) /srv/pillar/base/qvm/sys-usb-allow-mouse.sls
+%config(noreplace) /srv/pillar/base/qvm/sys-usb-allow-mouse.top
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-net.sls
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-net.top
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-firewall.sls


### PR DESCRIPTION
1. Default to 'ask' action for qubes.InputMouse for sys-usb, but allow to force
   'allow' via pillar.
2. Do not attach to sys-usb controllers selected to remain in dom0 (via
   rd.qubes.dom0_usb on kernel cmdline).

QubesOS/qubes-issues#3722
QubesOS/qubes-issues#2116