### PR TITLE
Enable usbguard for dom0, when setting up USB keyboard

### DIFF
--- a/qvm/usb-keyboard.sls
+++ b/qvm/usb-keyboard.sls
@@ -41,14 +41,14 @@ unhide-usb-from-dom0-uefi:
   file.replace:
     - name: {{ uefi_xen_cfg }}
     - pattern: ' rd.qubes.hide_all_usb'
-    - repl: ''
+    - repl: ' usbcore.authorized_default=0'
     - onlyif: test -f {{ uefi_xen_cfg }}
 
 unhide-usb-from-dom0-grub:
   file.replace:
     - name: /etc/default/grub
     - pattern: ' rd.qubes.hide_all_usb'
-    - repl: ''
+    - repl: ' usbcore.authorized_default=0'
     - onlyif: test -f /etc/default/grub
 
 grub-regenerate-unhide:


### PR DESCRIPTION
core-admin-linux repo now ships an usbguard configuration (and a dracut
module to include it there too), that enables it whenever
`usbcore.authorized_default=0` option is set.

QubesOS/qubes-issues#6959