### PR TITLE
Do not override stub grub.cfg on EFI partition

### DIFF
--- a/qvm/hide-usb-from-dom0.sls
+++ b/qvm/hide-usb-from-dom0.sls
@@ -12,11 +12,7 @@
 ##
 
 {% set uefi_xen_cfg = '/boot/efi/EFI/qubes/xen.cfg' %}
-{% if grains['boot_mode'] == 'efi' %}
-{% set grub_cfg = '/boot/efi/EFI/qubes/grub.cfg' %}
-{% else %}
 {% set grub_cfg = '/boot/grub2/grub.cfg' %}
-{% endif %}
 
 # file.line module is supported only in salt 2015.08 or later...
 hide-usb-from-dom0-uefi:

--- a/qvm/usb-keyboard.sls
+++ b/qvm/usb-keyboard.sls
@@ -31,11 +31,7 @@ sys-usb-input-proxy-keyboard:
 
 
 {% set uefi_xen_cfg = '/boot/efi/EFI/qubes/xen.cfg' %}
-{% if grains['boot_mode'] == 'efi' %}
-{% set grub_cfg = '/boot/efi/EFI/qubes/grub.cfg' %}
-{% else %}
 {% set grub_cfg = '/boot/grub2/grub.cfg' %}
-{% endif %}
 
 unhide-usb-from-dom0-uefi:
   file.replace:


### PR DESCRIPTION
Grub2 in R4.2 is made to include grub.cfg from primary /boot partition,
even on EFI systems - so it always lives in the same place. Do not not
override the config stub.

QubesOS/qubes-issues#7985