### PR TITLE
Add optional USB keyboard setup also during initial sys-usb setup

### DIFF
--- a/pillar/qvm/usb-keyboard.sls
+++ b/pillar/qvm/usb-keyboard.sls
@@ -1,0 +1,3 @@
+qvm:
+  sys-usb:
+    keyboard-action: allow

--- a/pillar/qvm/usb-keyboard.top
+++ b/pillar/qvm/usb-keyboard.top
@@ -1,0 +1,4 @@
+base:
+  dom0:
+    - match: nodegroup
+    - qvm.usb-keyboard

--- a/qvm/hide-usb-from-dom0.sls
+++ b/qvm/hide-usb-from-dom0.sls
@@ -21,15 +21,24 @@
 # file.line module is supported only in salt 2015.08 or later...
 hide-usb-from-dom0-uefi:
   cmd.run:
+{% if salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') == 'allow' %}
+    - name: sed -i -e 's/^kernel=.*/\0 usbcore.authorized_default=0/' {{ uefi_xen_cfg }}
+    - unless: grep usbcore.authorized_default {{ uefi_xen_cfg }}
+{% else %}
     - name: sed -i -e 's/^kernel=.*/\0 rd.qubes.hide_all_usb/' {{ uefi_xen_cfg }}
     - unless: grep rd.qubes.hide_all_usb {{ uefi_xen_cfg }}
+{% endif %}
     - onlyif: test -f {{uefi_xen_cfg}}
 
 
 hide-usb-from-dom0-grub:
   file.append:
     - name: /etc/default/grub
+{% if salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') == 'allow' %}
+    - text: GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX usbcore.authorized_default=0"
+{% else %}
     - text: GRUB_CMDLINE_LINUX="$GRUB_CMDLINE_LINUX rd.qubes.hide_all_usb"
+{% endif %}
     - onlyif: test -f /etc/default/grub
 
 

--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -99,6 +99,17 @@ sys-usb-input-proxy:
     - require:
       - pkg:       qubes-input-proxy
 
+{% if salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') != 'deny' %}
+sys-usb-input-proxy-kbd:
+  file.prepend:
+    - name: /etc/qubes-rpc/policy/qubes.InputKeyboard
+{% if salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') == 'ask' %}
+    - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 ask,default_target=dom0
+{% elif salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') == 'allow' %}
+    - text: {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 allow
+{% endif %}
+{% endif %}
+
 /etc/systemd/system/qubes-vm@{{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }}.service.d/50_autostart.conf:
   file.managed:
     - contents: |

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
@@ -135,6 +135,8 @@ fi
 %config(noreplace) /srv/pillar/base/qvm/sys-gui-vnc.top
 %config(noreplace) /srv/pillar/base/qvm/sys-usb-allow-mouse.sls
 %config(noreplace) /srv/pillar/base/qvm/sys-usb-allow-mouse.top
+%config(noreplace) /srv/pillar/base/qvm/usb-keyboard.sls
+%config(noreplace) /srv/pillar/base/qvm/usb-keyboard.top
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-net.sls
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-net.top
 %config(noreplace) /srv/pillar/base/qvm/disposable-sys-firewall.sls


### PR DESCRIPTION
This basically performs what qvm.usb-keyboard does, but while applying
initial qvm.sys-usb state, not after it.

QubesOS/qubes-issues#7674