### PR TITLE
Increase default size of sys-usb

### DIFF
--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -49,7 +49,7 @@ present:
   - template:  {{default_template}}-dvm
   {% endif %}
   - label:     red
-  - mem:       300
+  - mem:       400
   - flags:
     - net
 prefs:


### PR DESCRIPTION
Especially with webcams or other high-throughput devices, usbip driver
requires more memory. This is going to be even more important with
qubes-video-companion.

Fixes QubesOS/qubes-issues#6200