### PR TITLE
Change name of default disposable template to default-dvm

### DIFF
--- a/qvm/default-dispvm.sls
+++ b/qvm/default-dispvm.sls
@@ -14,7 +14,7 @@
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 {% set default_template = salt['cmd.shell']('qubes-prefs default-template') %}
 
-{{default_template}}-dvm:
+default-dvm:
   qvm.vm:
    - present:
      - label: red
@@ -26,8 +26,8 @@
        - appmenus-dispvm
 
 # Handle org.gnome.Terminal, xfce4-terminal, and xterm, as well as firefox vs firefox-esr
-qvm-appmenus --get-default-whitelist {{default_template}} | grep -i 'firefox\|term' | qvm-appmenus --set-whitelist=- --update {{default_template}}-dvm:
+qvm-appmenus --get-default-whitelist {{default_template}} | grep -i 'firefox\|term' | qvm-appmenus --set-whitelist=- --update default-dvm:
   cmd.run:
     - runas: {{ gui_user }}
     - requires:
-      - qvm: {{default_template}}-dvm
+      - qvm: default-dvm

--- a/qvm/sys-firewall.sls
+++ b/qvm/sys-firewall.sls
@@ -31,7 +31,7 @@ name:          sys-firewall
 present:
   {% if salt['pillar.get']('qvm:sys-firewall:disposable', false) %}
   - class:     DispVM
-  - template:  {{default_template}}-dvm
+  - template:  default-dvm
   {% endif %}
   - label:     green
 prefs:
@@ -41,7 +41,7 @@ prefs:
   - memory:       500
 require:
   {% if salt['pillar.get']('qvm:sys-firewall:disposable', false) %}
-  - qvm:       {{default_template}}-dvm
+  - qvm:       default-dvm
   {% endif %}
   - qvm:       sys-net
 {%- endload %}

--- a/qvm/sys-net.sls
+++ b/qvm/sys-net.sls
@@ -30,7 +30,7 @@ name:          sys-net
 present:
   {% if salt['pillar.get']('qvm:sys-net:disposable', false) %}
   - class:     DispVM
-  - template:  {{default_template}}-dvm
+  - template:  default-dvm
   {% endif %}
   - label:     red
 prefs:
@@ -47,7 +47,7 @@ service:
     - meminfo-writer
 {% if salt['pillar.get']('qvm:sys-net:disposable', false) %}
 require:
-  - qvm:       {{default_template}}-dvm
+  - qvm:       default-dvm
 {% endif %}
 {%- endload %}
 

--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -46,7 +46,7 @@ name:          sys-usb
 present:
   {% if salt['pillar.get']('qvm:sys-usb:disposable', false) %}
   - class:     DispVM
-  - template:  {{default_template}}-dvm
+  - template:  default-dvm
   {% endif %}
   - label:     red
   - mem:       400
@@ -64,7 +64,7 @@ service:
     - meminfo-writer
 {% if salt['pillar.get']('qvm:sys-usb:disposable', false) %}
 require:
-  - qvm:       {{default_template}}-dvm
+  - qvm:       default-dvm
 {% endif %}
 {%- endload %}
 


### PR DESCRIPTION
Do not put the template name in the disposable template name, it makes
updates (or other changes of its template) confusing. For example,
user may have fedora-37-dvm, but later when updating to fedora-38, its
name could be confusing if it remains the same.

Fixes QubesOS/qubes-issues#8071