### PR TITLE
Rename short whonix-(gw|ws) names to their full names

### DIFF
--- a/pillar/qvm/init.sls
+++ b/pillar/qvm/init.sls
@@ -15,30 +15,30 @@ qvm-disabled:
   debug: true
   force: true
 
-  whonix-gw:
+  whonix-gateway:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - qvm:       template-whonix-gw
+      - qvm:       template-whonix-gateway
       - qvm:       test-sys-whonix
 
-  whonix-ws:
+  whonix-workstation:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - qvm:       template-whonix-ws
+      - qvm:       template-whonix-workstation
       - qvm:       test-sys-whonix
 
   sys-whonix:
     name:          test-sys-whonix
     #present:
-    #  - template:  whonix-gw
+    #  - template:  whonix-gateway
     #  - label:     yellow
     #  - mem:       600
     #  - flags:
     #    - proxy
     require:
-      - qvm:       template-whonix-gw
+      - qvm:       template-whonix-gateway
       - qvm:       test-sys-firewall
 
   anon-whonix:
@@ -46,7 +46,7 @@ qvm-disabled:
     prefs:
       - netvm:     test-sys-whonix
     require:
-      - qvm:       template-whonix-ws
+      - qvm:       template-whonix-workstation
       - qvm:       test-sys-whonix
 
   work:

--- a/qvm/anon-whonix.sls
+++ b/qvm/anon-whonix.sls
@@ -17,9 +17,9 @@
 ##
 
 include:
-  - qvm.template-whonix-ws
+  - qvm.template-whonix-workstation
   - qvm.sys-whonix
-  - qvm.whonix-ws-dvm
+  - qvm.whonix-workstation-dvm
 
 {%- import "qvm/whonix.jinja" as whonix -%}
 {%- from "qvm/template.jinja" import load -%}
@@ -27,18 +27,18 @@ include:
 {% load_yaml as defaults -%}
 name:          anon-whonix
 present:
-  - template:  whonix-ws-{{ whonix.whonix_version }}
+  - template:  whonix-workstation-{{ whonix.whonix_version }}
   - label:     red
 prefs:
   - netvm:     sys-whonix
-  - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm
+  - default-dispvm: whonix-workstation-{{ whonix.whonix_version }}-dvm
 tags:
   - add:
     - anon-vm
 require:
-  - qvm:       template-whonix-ws-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-workstation-{{ whonix.whonix_version }}
   - qvm:       sys-whonix
-  - qvm:       whonix-ws-{{ whonix.whonix_version }}-dvm
+  - qvm:       whonix-workstation-{{ whonix.whonix_version }}-dvm
 {%- endload %}
 
 {{ load(defaults) }}

--- a/qvm/sys-whonix.sls
+++ b/qvm/sys-whonix.sls
@@ -17,7 +17,7 @@
 ##
 
 include:
-  - qvm.template-whonix-gw
+  - qvm.template-whonix-gateway
   - qvm.sys-firewall
 
 {%- import "qvm/whonix.jinja" as whonix -%}
@@ -26,7 +26,7 @@ include:
 {% load_yaml as defaults -%}
 name:          sys-whonix
 present:
-  - template:  whonix-gw-{{ whonix.whonix_version }}
+  - template:  whonix-gateway-{{ whonix.whonix_version }}
   - label:     black
   - mem:       500
 prefs:
@@ -34,7 +34,7 @@ prefs:
   - provides-network: true
   - autostart: true
 require:
-  - qvm:       template-whonix-gw-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-gateway-{{ whonix.whonix_version }}
   - qvm:       sys-firewall
 {%- endload %}
 

--- a/qvm/template-whonix-gateway.sls
+++ b/qvm/template-whonix-gateway.sls
@@ -2,25 +2,25 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 ##
-# qvm.template-whonix-gw
+# qvm.template-whonix-gateway
 # ======================
 #
-# Installs 'whonix-gw' template.
+# Installs 'whonix-gateway' template.
 #
 # Execute:
-#   qubesctl state.sls qvm.template-whonix-gw dom0
+#   qubesctl state.sls qvm.template-whonix-gateway dom0
 ##
 
 {% import "qvm/whonix.jinja" as whonix -%}
 
-template-whonix-gw-{{ whonix.whonix_version }}:
+template-whonix-gateway-{{ whonix.whonix_version }}:
   qvm.template_installed:
-    - name:     whonix-gw-{{ whonix.whonix_version }}
+    - name:     whonix-gateway-{{ whonix.whonix_version }}
     - fromrepo: {{ whonix.whonix_repo }}
 
-whonix-gw-tag:
+whonix-gateway-tag:
   qvm.vm:
-    - name: whonix-gw-{{ whonix.whonix_version }}
+    - name: whonix-gateway-{{ whonix.whonix_version }}
     - tags:
       - present:
         - whonix-updatevm
@@ -28,7 +28,7 @@ whonix-gw-tag:
       - enable:
         - whonix-gw
 
-whonix-gw-update-policy:
+whonix-gateway-update-policy:
   file.prepend:
     - name: /etc/qubes/policy.d/50-config-updates.policy
     - text:

--- a/qvm/template-whonix-workstation.sls
+++ b/qvm/template-whonix-workstation.sls
@@ -2,25 +2,25 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 ##
-# qvm.template-whonix-ws
+# qvm.template-whonix-workstation
 # ======================
 #
-# Installs 'whonix-ws' template.
+# Installs 'whonix-workstation' template.
 #
 # Execute:
-#   qubesctl state.sls qvm.template-whonix-ws dom0
+#   qubesctl state.sls qvm.template-whonix-workstation dom0
 ##
 
 {% import "qvm/whonix.jinja" as whonix -%}
 
-template-whonix-ws-{{ whonix.whonix_version }}:
+template-whonix-workstation-{{ whonix.whonix_version }}:
   qvm.template_installed:
-    - name:     whonix-ws-{{ whonix.whonix_version }}
+    - name:     whonix-workstation-{{ whonix.whonix_version }}
     - fromrepo: {{ whonix.whonix_repo }}
 
-whonix-ws-tag:
+whonix-workstation-tag:
   qvm.vm:
-    - name: whonix-ws-{{ whonix.whonix_version }}
+    - name: whonix-workstation-{{ whonix.whonix_version }}
     - tags:
       - present:
         - whonix-updatevm
@@ -28,7 +28,7 @@ whonix-ws-tag:
       - enable:
         - whonix-ws
 
-whonix-ws-update-policy:
+whonix-workstation-update-policy:
   file.prepend:
     - name: /etc/qubes/policy.d/50-config-updates.policy
     - text:

--- a/qvm/whonix-workstation-dvm.sls
+++ b/qvm/whonix-workstation-dvm.sls
@@ -2,22 +2,22 @@
 # vim: set syntax=yaml ts=2 sw=2 sts=2 et :
 
 ##
-# qvm.whonix-ws-dvm
+# qvm.whonix-workstation-dvm
 # ===============
 #
-# Installs 'whonix-ws-dvm' AppVM as a base for Disposable VMs.
+# Installs 'whonix-workstation-dvm' AppVM as a base for Disposable VMs.
 #
 # Pillar data will also be merged if available within the ``qvm`` pillar key:
-#   ``qvm:whonix-ws-dvm``
+#   ``qvm:whonix-workstation-dvm``
 #
 # located in ``/srv/pillar/dom0/qvm/init.sls``
 #
 # Execute:
-#   qubesctl state.sls qvm.whonix-ws-dvm dom0
+#   qubesctl state.sls qvm.whonix-workstation-dvm dom0
 ##
 
 include:
-  - qvm.template-whonix-ws
+  - qvm.template-whonix-workstation
   - qvm.sys-whonix
 
 {%- import "qvm/whonix.jinja" as whonix -%}
@@ -26,14 +26,14 @@ include:
 {% set gui_user = salt['cmd.shell']('groupmems -l -g qubes') %}
 
 {% load_yaml as defaults -%}
-name:          whonix-ws-{{ whonix.whonix_version }}-dvm
+name:          whonix-workstation-{{ whonix.whonix_version }}-dvm
 present:
-  - template:  whonix-ws-{{ whonix.whonix_version }}
+  - template:  whonix-workstation-{{ whonix.whonix_version }}
   - label:     red
 prefs:
   - netvm:     sys-whonix
   - template-for-dispvms: true
-  - default-dispvm: whonix-ws-{{ whonix.whonix_version }}-dvm
+  - default-dispvm: whonix-workstation-{{ whonix.whonix_version }}-dvm
 tags:
   - add:
     - anon-vm
@@ -41,14 +41,14 @@ features:
   - enable:
     - appmenus-dispvm
 require:
-  - qvm:       template-whonix-ws-{{ whonix.whonix_version }}
+  - qvm:       template-whonix-workstation-{{ whonix.whonix_version }}
   - qvm:       sys-whonix
 {%- endload %}
 
-qvm-appmenus --update whonix-ws-{{ whonix.whonix_version }}-dvm:
+qvm-appmenus --update whonix-workstation-{{ whonix.whonix_version }}-dvm:
   cmd.run:
     - runas: {{ gui_user }}
     - onchanges:
-      - qvm:  whonix-ws-{{ whonix.whonix_version }}-dvm
+      - qvm:  whonix-workstation-{{ whonix.whonix_version }}-dvm
 
 {{ load(defaults) }}

--- a/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
+++ b/rpm_spec/qubes-mgmt-salt-dom0-virtual-machines-dom0.spec.in
@@ -104,8 +104,8 @@ fi
 /srv/formulas/base/virtual-machines-formula/qvm/sys-whonix.top
 /srv/formulas/base/virtual-machines-formula/qvm/template.jinja
 /srv/formulas/base/virtual-machines-formula/qvm/template-gui.jinja
-/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-gw.sls
-/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-ws.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-gateway.sls
+/srv/formulas/base/virtual-machines-formula/qvm/template-whonix-workstation.sls
 /srv/formulas/base/virtual-machines-formula/qvm/untrusted.sls
 /srv/formulas/base/virtual-machines-formula/qvm/untrusted.top
 /srv/formulas/base/virtual-machines-formula/qvm/updates-via-whonix.sls
@@ -115,7 +115,7 @@ fi
 /srv/formulas/base/virtual-machines-formula/qvm/vault.sls
 /srv/formulas/base/virtual-machines-formula/qvm/vault.top
 /srv/formulas/base/virtual-machines-formula/qvm/whonix.jinja
-/srv/formulas/base/virtual-machines-formula/qvm/whonix-ws-dvm.sls
+/srv/formulas/base/virtual-machines-formula/qvm/whonix-workstation-dvm.sls
 /srv/formulas/base/virtual-machines-formula/qvm/work.sls
 /srv/formulas/base/virtual-machines-formula/qvm/work.top
 


### PR DESCRIPTION
Whonix 17 use full "workstation" and "gateway" names, instead of whort
"ws" and "gw" versions. Rename all template name instances, but also
rename relevant state files.
The only remaining short form is "feature" name, as this is part of API.

This is not tested yet.

QubesOS/qubes-issues#1778