### PR TITLE
sys-gui: set dom0 as audiovm for sys-gui

### DIFF
--- a/qvm/sys-gui.sls
+++ b/qvm/sys-gui.sls
@@ -30,7 +30,7 @@ present:
 prefs:
   - netvm:     ""
   - guivm:     dom0
-  - audiovm:   ""
+  - audiovm:   dom0
   - autostart: true
 service:
   - enable:


### PR DESCRIPTION
sys-gui doesn't have PCI devices, especially not a sound card, so, set
dom0 as audiovm for it.
This also allows clean pulseaudio startup in sys-gui, otherwise it waits
for /qubes-audio-domain-xid key (and fail, repeatedly).