### PR TITLE
Allow audiovm accessing stubdom_xid too

### DIFF
--- a/qvm/sys-audio.sls
+++ b/qvm/sys-audio.sls
@@ -49,7 +49,10 @@ sys-audio-rpc:
         admin.vm.List         *   sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
         admin.vm.property.Get               +audiovm sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
         admin.vm.property.Get               +xid     sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
+        admin.vm.property.Get               +stubdom_xid     sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
+        admin.vm.property.Get               +virt_mode     sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
         admin.vm.feature.CheckWithTemplate  +audio   sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
+        admin.vm.feature.CheckWithTemplate  +audio-model   sys-audio     @tag:audiovm-sys-audio  allow   target=dom0
 
 {% else %}
 


### PR DESCRIPTION
It's needed for HVM stubdom audio

QubesOS/qubes-issues#7388