### PR TITLE
sys-usb: mark explicitly as service qube

### DIFF
--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -62,6 +62,9 @@ service:
   - disable:
     - network-manager
     - meminfo-writer
+features:
+  - set:
+    - servicevm: 1
 {% if salt['pillar.get']('qvm:sys-usb:disposable', false) %}
 require:
   - qvm:       default-dvm


### PR DESCRIPTION
Ensures sys-usb still remains a service qube, even if it is no longer marked as "provides network". 

Fixes https://github.com/QubesOS/qubes-issues/issues/7298