### PR TITLE
Minimize package manager calls

### DIFF
--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -10,13 +10,13 @@ sys-gui-gpu-template:
   qvm.template_installed:
     - name: {{ salt['pillar.get']('qvm:sys-gui-gpu:template', 'fedora-40-xfce') }}
 
+sys-gui-gpu-installed:
+  pkg.installed:
+    - pkgs:
+      - qubes-input-proxy-sender
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui-gpu:dummy-modules', []) %}
-dummy-psu-sender:
-  pkg.installed: []
+      - dummy-psu-sender
 {% endif %}
-
-qubes-input-proxy-sender:
-  pkg.installed: []
 
 {% from "qvm/template.jinja" import load -%}
 {% from "qvm/template-gui.jinja" import gui_common -%}

--- a/qvm/sys-gui-vnc.sls
+++ b/qvm/sys-gui-vnc.sls
@@ -9,13 +9,16 @@
 {{ salt['pillar.get']('qvm:sys-gui-vnc:template', 'fedora-40-xfce') }}:
   qvm.template_installed: []
 
+{% if 'psu' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) or 'backlight' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) %}
+sys-gui-vnc-installed:
+  pkg.installed:
+    - pkgs:
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) %}
-dummy-psu-sender:
-  pkg.installed: []
+      - dummy-psu-sender
 {% endif %}
 {% if 'backlight' in salt['pillar.get']('qvm:sys-gui-vnc:dummy-modules', []) %}
-dummy-backlight-dom0:
-  pkg.installed: []
+      - dummy-backlight-dom0
+{% endif %}
 {% endif %}
 
 {% from "qvm/template.jinja" import load -%}

--- a/qvm/sys-gui.sls
+++ b/qvm/sys-gui.sls
@@ -9,13 +9,16 @@
 {{ salt['pillar.get']('qvm:sys-gui:template', 'fedora-40-xfce') }}:
   qvm.template_installed: []
 
+{% if 'psu' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) or 'backlight' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
+sys-gui-installed:
+  pkg.installed:
+    - pkgs:
 {% if 'psu' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
-dummy-psu-sender:
-  pkg.installed: []
+      - dummy-psu-sender
 {% endif %}
 {% if 'backlight' in salt['pillar.get']('qvm:sys-gui:dummy-modules', []) %}
-dummy-backlight-dom0:
-  pkg.installed: []
+      - dummy-backlight-dom0
+{% endif %}
 {% endif %}
 
 {% from "qvm/template.jinja" import load -%}


### PR DESCRIPTION
Fast dom0 package installation as it only calls the updatevm proxy once.

---

It is even more critical when using a slow network such as Tor on the updatevm.