### PR TITLE
Don't use shadow.info

### DIFF
--- a/pillar/qvm/sys-gui-gpu.sls
+++ b/pillar/qvm/sys-gui-gpu.sls
@@ -5,7 +5,7 @@
 {% set user = salt['group.info']('qubes').get('members')[0] %}
 # 'password_hash' is obtained from /etc/shadow with corresponding
 # user set above.
-{% set password_hash = salt['shadow.info'](user).get('passwd') %}
+{% set password_hash = salt['cmd.run']("getent shadow " + user).split(":")[1] %}
 
 # Default password is set to '123456'
 {% if password_hash == '' %}

--- a/pillar/qvm/sys-gui-vnc.sls
+++ b/pillar/qvm/sys-gui-vnc.sls
@@ -5,7 +5,7 @@
 {% set user = salt['group.info']('qubes').get('members')[0] %}
 # 'password_hash' is obtained from /etc/shadow with corresponding
 # user set above.
-{% set password_hash = salt['shadow.info'](user).get('passwd') %}
+{% set password_hash = salt['cmd.run']("getent shadow " + user).split(":")[1] %}
 
 # Default password is set to '123456'
 {% if password_hash == '' %}


### PR DESCRIPTION
It relies on Python's spwd module which has been removed in Python 3.13.
Call `getent shadow` instead.

QubesOS/qubes-issues#9402