### PR TITLE
Increase sys-net default memory size

### DIFF
--- a/qvm/sys-net.sls
+++ b/qvm/sys-net.sls
@@ -38,7 +38,7 @@ prefs:
   - virt_mode: hvm
   - autostart: true
   - provides-network: true
-  - memory: 400
+  - memory: 425
   - pcidevs:   {{ salt['grains.get']('pci_net_devs', [])|yaml }}
 service:
   - enable:


### PR DESCRIPTION
There were several reports that some network drivers fail with "page
allocation failure" with 400MB sys-net. Increase default size to 425MB
which seems to be enough to fix at least some of those issues. More
long-term solution would be reducing amount of software running in
sys-net.

Fixes QubesOS/qubes-issues#9333
Fixes QubesOS/qubes-issues#3008