### PR TITLE
Enable minimal netvm/usbvm services

### DIFF
--- a/qvm/sys-net.sls
+++ b/qvm/sys-net.sls
@@ -38,11 +38,12 @@ prefs:
   - virt_mode: hvm
   - autostart: true
   - provides-network: true
-  - memory: 425
+  - memory: 300
   - pcidevs:   {{ salt['grains.get']('pci_net_devs', [])|yaml }}
 service:
   - enable:
     - clocksync
+    - minimal-netvm
   - disable:
     - meminfo-writer
 {% if salt['pillar.get']('qvm:sys-net:disposable', false) %}

--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -49,7 +49,7 @@ present:
   - template:  default-dvm
   {% endif %}
   - label:     red
-  - mem:       400
+  - mem:       300
   - flags:
     - net
 prefs:
@@ -62,6 +62,8 @@ service:
   - disable:
     - network-manager
     - meminfo-writer
+  - enable:
+    - minimal-usbvm
 {% if salt['pillar.get']('qvm:sys-usb:disposable', false) %}
 require:
   - qvm:       default-dvm


### PR DESCRIPTION
Reduce memory usage of those system qubes. This allows getting back to
the default 300MB size.

https://github.com/QubesOS/qubes-issues/issues/7028