### PR TITLE
Do not set custom kernelopts for sys-gui-gpu anymore

### DIFF
--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -34,10 +34,7 @@ prefs:
   - audiovm:   ""
   - memory:    1000
   - autostart: false #TODO true
-  - kernelopts: "nopat iommu=soft swiotlb=8192 root=/dev/mapper/dmroot ro console=hvc0 xen_scrub_pages=0"
 features:
-  - enable:
-    - no-default-kernelopts
   - set:
     - video-model: none
     - input-dom0-proxy: true


### PR DESCRIPTION
With automatic filtering of nomodeset option, there is no need to set
the options manually anymore.

QubesOS/qubes-issues#9792