### PR TITLE
Fix policy for keyboard/mouse with sys-gui-gpu

### DIFF
--- a/qvm/sys-gui-gpu.sls
+++ b/qvm/sys-gui-gpu.sls
@@ -74,7 +74,9 @@ sys-usb-input-proxy:
     - name: /etc/qubes/policy.d/45-sys-gui-gpu.policy
     - contents: |
         qubes.InputMouse * {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 {{ mouse_action }}
+        qubes.InputMouse * {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} sys-gui-gpu {{ mouse_action }}
         qubes.InputKeyboard * {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 {{ keyboard_action }}
+        qubes.InputKeyboard * {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} sys-gui-gpu {{ keyboard_action }}
         # not configurable by this state
         qubes.InputTablet * {{ salt['pillar.get']('qvm:sys-usb:name', 'sys-usb') }} dom0 deny
 


### PR DESCRIPTION
When the action is 'ask default_target=sys-gui-gpu', there needs to be
another rule actually allowing the sys-gui-gpu target. Contrary to the
'allow target=sys-gui-gpu', the ask's default_target= parameter doesn't
implicitly allow that target.

Add the rule for allow (and deny) too for simplicy, but it's actually
needed only for the 'ask' action.

Fixes QubesOS/qubes-issues#9980