### PR TITLE
sys-gui: allowlist utilized admin.vm.property calls

### DIFF
--- a/qvm/template-gui.jinja
+++ b/qvm/template-gui.jinja
@@ -41,6 +41,9 @@
         admin.label.Index                   *   {{ vmname }}             dom0                             allow
         admin.vm.feature.Set +keyboard-layout   {{ vmname }}             {{ vmname }}                     allow target=dom0
         admin.vm.property.Get               *   {{ vmname }}             dom0                             allow
+        admin.vm.property.Get    +stubdom_xid   {{ vmname }}             @tag:guivm-{{ vmname }}          allow target=dom0
+        admin.vm.property.Get            +xid   {{ vmname }}             @tag:guivm-{{ vmname }}          allow target=dom0
+        admin.vm.property.GetAll            *   {{ vmname }}             @tag:guivm-{{ vmname }}          allow target=dom0
         admin.vm.volume.List                *   {{ vmname }}             dom0                             allow
         admin.vm.device.pci.Available       *   {{ vmname }}             dom0                             allow
         admin.vm.device.mic.Available       *   {{ vmname }}             dom0                             allow


### PR DESCRIPTION
Allow these procedures even if a wildcard default-deny policy exists

E.g. using https://github.com/ben-grande/qusal/blob/bcea67d353902c3cc649e7b029ecd48c78e90bd2/salt/sys-audio/files/admin/policy/default.policy#L49-L55 will block these calls and seems sane to support (while still overriding) such user policies.