### PR TITLE
sys-gui: allow getting template props

### DIFF
--- a/qvm/template-gui.jinja
+++ b/qvm/template-gui.jinja
@@ -41,9 +41,9 @@
         admin.label.Index                   *   {{ vmname }}             dom0                             allow
         admin.vm.feature.Set +keyboard-layout   {{ vmname }}             {{ vmname }}                     allow target=dom0
         admin.vm.property.Get               *   {{ vmname }}             dom0                             allow
-        admin.vm.property.Get       +template   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
+        admin.vm.property.Get       +template   {{ vmname }}             @tag:guivm-{{ vmname }}          allow target=dom0
         # TODO: limit to templates related to @tag:guivm-{{ vmname }} only
-        admin.vm.property.Get       +template   {{ vmname }}             @type:TemplateVM                 allow
+        admin.vm.property.Get       +template   {{ vmname }}             @type:TemplateVM                 allow target=dom0
         admin.vm.volume.List                *   {{ vmname }}             dom0                             allow
         admin.vm.device.pci.Available       *   {{ vmname }}             dom0                             allow
         admin.vm.device.mic.Available       *   {{ vmname }}             dom0                             allow


### PR DESCRIPTION
Recursively accessing templates and related metadata seems required in order to properly sync appmenu entries and icons. The integration doesn't seem to work without these calls. Is there a way to avoid requiring these permissions?