### PR TITLE
sys-gui: ask qubes.Filecopy

### DIFF
--- a/qvm/template-gui.jinja
+++ b/qvm/template-gui.jinja
@@ -17,6 +17,7 @@
         qubes.GetAppmenus                   *   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
         qubes.ClipboardCopy                 +   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
         qubes.ClipboardPaste                +   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
+        qubes.Filecopy                      *   {{ vmname }}             @tag:guivm-{{ vmname }}          ask
         # TODO: limit to templates related to @tag:guivm-{{ vmname }} only
         qubes.GetAppmenus                   *   {{ vmname }}             @type:TemplateVM                 allow
         qubes.SetMonitorLayout              *   {{ vmname }}             @tag:guivm-{{ vmname }}          allow


### PR DESCRIPTION
Without this rule, getting denies with:

    warning: policy define default_target=None at /etc/qubes/policy.d/90-default.policy:31 but it is not amoung allowed targets(...,myvm,...)
    qrexec: qubes.Filecopy: sys-gui-gpu -> myvm: denied: denied by the user /etc/qubes/policy.d/90-default.policy:31

https://github.com/QubesOS/qubes-core-admin/blob/bc20defa8f7ba9de048d64d2d9e9da7b1db21c7d/qubes-rpc-policy/90-default.policy#L31