### PR TITLE
Prioritize sys-usb startup also when usb keyboard is enabled via pillar

### DIFF
--- a/qvm/sys-usb.sls
+++ b/qvm/sys-usb.sls
@@ -35,6 +35,9 @@ include:
   - qvm.default-dispvm
   {% endif %}
   - qvm.hide-usb-from-dom0
+  {% if salt['pillar.get']('qvm:sys-usb:keyboard-action', 'deny') == 'allow' %}
+  - qvm.sys-usb-prioritize-autostart
+  {% endif %}
 
 {% from "qvm/template.jinja" import load -%}
 


### PR DESCRIPTION
Initial setup enables USB keyboard via pillar, to be configured when initially
setting up sys-usb. Prioritize sys-usb startup in this case too.