### PR TITLE
Do not start guivm for notifications

### DIFF
--- a/qvm/template-gui.jinja
+++ b/qvm/template-gui.jinja
@@ -24,7 +24,7 @@
         qubes.StartApp                      *   {{ vmname }}             @dispvm:@tag:guivm-{{ vmname }}  allow
         qubes.SyncAppMenus                  *   @tag:guivm-{{ vmname }}  dom0                        allow   target={{ vmname }}
         qubes.WindowIconUpdater             *   @tag:guivm-{{ vmname }}  dom0                        allow   target={{ vmname }}
-        qubes.Notifications                 *   @tag:guivm-{{ vmname }}  @default                    allow   target={{ vmname }}
+        qubes.Notifications                 *   @tag:guivm-{{ vmname }}  @default                    allow   target={{ vmname }} autostart=no
         qubes.WaitForSession                *   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
 {%- if 'psu' in salt['pillar.get']('qvm:' + vmname + ':dummy-modules', []) %}
         qubes.PowerSupply                   *   {{ vmname }}             @default                         allow target=dom0


### PR DESCRIPTION
Notifications proxy is started before GUI agent, so just starting a VM
will trigger the service. Theoretically starting associated GUI domain
shouldn't be an issue (to have where to show the notification), but in
practice there are a few corner cases here:
 - when setting up GUI domain (especially sys-gui-gpu) there are a bunch
   of steps involved, and starting it too early may interrupt them (as
   sys-gui-gpu takes keyboard/mouse away from dom0).
 - just starting GUI domain usually won't make notifications work yet -
   user needs to log into that GUI domain first

QubesOS/qubes-issues#889