### PR TITLE
Allow GUIVM clients to know if GUIVM has session

### DIFF
--- a/qvm/template-gui.jinja
+++ b/qvm/template-gui.jinja
@@ -25,6 +25,7 @@
         qubes.SyncAppMenus                  *   @tag:guivm-{{ vmname }}  dom0                        allow   target={{ vmname }}
         qubes.WindowIconUpdater             *   @tag:guivm-{{ vmname }}  dom0                        allow   target={{ vmname }}
         qubes.Notifications                 *   @tag:guivm-{{ vmname }}  @default                    allow   target={{ vmname }} autostart=no
+        qubes.WaitForSession                *   @tag:guivm-{{ vmname }}  @default                    allow   target={{ vmname }} autostart=no
         qubes.WaitForSession                *   {{ vmname }}             @tag:guivm-{{ vmname }}          allow
 {%- if 'psu' in salt['pillar.get']('qvm:' + vmname + ':dummy-modules', []) %}
         qubes.PowerSupply                   *   {{ vmname }}             @default                         allow target=dom0
@@ -80,4 +81,3 @@
         {{ vmname }} {{ vmname }} allow target=dom0
 {% endif %}
 {%- endmacro %}
-


### PR DESCRIPTION
Or if GUID of the client can be found on the server.

For: https://github.com/QubesOS/qubes-notification-proxy/pull/13
For: https://github.com/QubesOS/qubes-gui-agent-linux/pull/251
For: https://github.com/QubesOS/qubes-core-admin/pull/757
For: https://github.com/QubesOS/qubes-issues/issues/1512
For: https://github.com/QubesOS/qubes-issues/issues/9940
Fixes: https://github.com/QubesOS/qubes-issues/issues/10443