### PR TITLE
Drop obsolete adwaita-gtk2-theme from sys-gui formula

### DIFF
--- a/qvm/sys-gui-template.sls
+++ b/qvm/sys-gui-template.sls
@@ -36,7 +36,6 @@ sys-gui-xfce:
 {% if grains['os'] == 'Fedora' %}
       - dummy-psu-receiver
       - dummy-backlight-vm
-      - adwaita-gtk2-theme
       - adwaita-icon-theme
       - greybird-dark-theme
       - greybird-light-theme


### PR DESCRIPTION
The package wasn't used for a long time, and is no longer present in
Fedora 44.

QubesOS/qubes-issues#10703